### PR TITLE
Add OSS license wizard.

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -28,6 +28,9 @@ module.exports = class extends Generator {
       docker: ((this.options.docker.toLowerCase() === 'true') || (this.options.docker.toLowerCase() === 'yes')).toString() 
     };
 
+    this.composeWith(require.resolve('generator-license'), {
+      defaultLicense: 'MIT'
+    });
     this.composeWith(require.resolve('../build'));
     this.composeWith(require.resolve('../module'));
     this.composeWith(require.resolve('../example'));

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "generator-license": "^5.2.0",
+    "generator-license": "^5.4.0",
     "inquirer-npm-name": "^2.0.0",
     "lodash": "^4.17.4",
     "yeoman-generator": "^2.0.0"


### PR DESCRIPTION
* Uses [generator-license](https://github.com/jozefizso/generator-license)
* Default license is MIT
* Two additional parameters need to be provided by the user: `name` and `email`
* Package version is already updated in the previous PR #5 